### PR TITLE
protection. load shutdown if the temperature sensor data is not corre…

### DIFF
--- a/sonoff/xdrv_92_pid.ino
+++ b/sonoff/xdrv_92_pid.ino
@@ -184,7 +184,7 @@ void PID_Show_Sensor() {
   if (data_json.success()) {
     const char* value = data_json["DS18B20"]["Temperature"];
     // check that something was found and it contains a number
-    if (value != NULL  &&  strlen(value) > 0  &&  isdigit(value[0]) ) {
+    if (value != NULL  &&  strlen(value) > 0  &&  isdigit(value[0]) && strcmp(value,"0.0") ) {
       snprintf_P(log_data, sizeof(log_data), "PID_Show_Sensor: Temperature: %s", value);
       AddLog(LOG_LEVEL_INFO);
       // pass the value to the pid alogorithm to use as current pv
@@ -198,11 +198,13 @@ void PID_Show_Sensor() {
     } else {
       snprintf_P(log_data, sizeof(log_data), "PID_Show_Sensor - no temperature found");
       AddLog(LOG_LEVEL_INFO);
+      Timeprop_Set_Power( PID_USE_TIMPROP-1, 0 );
     }
   } else  {
     // parse failed
     snprintf_P(log_data, sizeof(log_data), "PID_Show_Sensor - json parse failed");
     AddLog(LOG_LEVEL_INFO);
+    Timeprop_Set_Power( PID_USE_TIMPROP-1, 0 );
   }
 }
 


### PR DESCRIPTION
For work, you can only use the internal DS18B20 library.
which returns zero if there is no data from the sensor. (This code does not work with other libraries.)

To prevent an emergency, the code disables the load if there are no temperature sensor data.